### PR TITLE
Custom Recorder should prevails over others

### DIFF
--- a/dev/GetRecorderType.js
+++ b/dev/GetRecorderType.js
@@ -63,12 +63,12 @@ function GetRecorderType(mediaStream, config) {
         }
     }
 
-    if (config.recorderType) {
-        recorder = config.recorderType;
-    }
-
     if (mediaStream instanceof Array && mediaStream.length) {
         recorder = MultiStreamRecorder;
+    }
+
+    if (config.recorderType) {
+        recorder = config.recorderType;
     }
 
     if (!config.disableLogs && !!recorder && !!recorder.name) {


### PR DESCRIPTION
It's not possible to use an extended/modified/custom MultiStreamRecorder because algorithm applies standard MultiStreamRecorder over configured in config